### PR TITLE
Set memory limits for Plex, OpenWakeWord, and Porcupine

### DIFF
--- a/plex/docker-compose.yaml
+++ b/plex/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - TZ=America/Los_Angeles
       - VERSION=docker
       - PLEX_CLAIM=${PLEX_CLAIM_TOKEN}
+    mem_limit: 16g
     network_mode: host
     volumes:
       - ~/docker/plex/appdata:/config

--- a/wyoming/docker-compose.yaml
+++ b/wyoming/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       - PUID=1000
       - PGID=999
       - TZ=America/Los_Angeles
+    mem_limit: 8g
     ports:
         - 10400:10400
     volumes:
@@ -24,6 +25,7 @@ services:
       - PUID=1000
       - PGID=999
       - TZ=America/Los_Angeles
+    mem_limit: 8g
     ports:
         - 10500:10400
     volumes:


### PR DESCRIPTION
* Set 16GB memory limit for Plex.
* Set 8GB memory limit for OpenWakeWord + Porcupine.